### PR TITLE
Fix Nip07 interface

### DIFF
--- a/src/nostr/nip07.ts
+++ b/src/nostr/nip07.ts
@@ -1,9 +1,8 @@
 export interface Nip07 {
-  getPublicKey: () => string;
+  getPublicKey: () => Promise<string>;
   signEvent: (event: {
     kind: number;
     tags: string[][];
-    pubkey: string;
     content: string;
     created_at: number;
   }) => Promise<{


### PR DESCRIPTION
This fixes NIP-07 type signatures based on NIP-07.

```typescript
async window.nostr.getPublicKey(): string // returns a public key as hex
async window.nostr.signEvent(event: Event): Event // takes an event object, adds `id`, `pubkey` and `sig` and returns it
```

ref: https://github.com/nostr-protocol/nips/blob/ccbdfb95c198c385595c18edac09d9c830fd9406/07.md#windownostr-capability-for-web-browsers