### PR TITLE
Add NodeNext support

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -3,7 +3,7 @@
 
 import { delay } from "rxjs";
 
-import { createRxBackwardReq, createRxNostr } from "../src";
+import { createRxBackwardReq, createRxNostr } from "../src/index.js";
 
 document.getElementById("send")?.addEventListener("click", async () => {
   const input = document.getElementById("input") as HTMLInputElement;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,16 @@
 export default {
-  preset: "ts-jest",
+  preset: "ts-jest/presets/default-esm",
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   transform: {
     "^.+\\.(js|jsx)$": "babel-jest",
-    "^.+\\.(ts|tsx)$": "ts-jest",
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      {
+        useESM: true,
+      }
+    ]
   },
   transformIgnorePatterns: ["^/node_modules/normalize-url"],
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.es.js",
-      "require": "./dist/index.umd.js"
+      "require": "./dist/index.umd.js",
+      "types": "./types/src/index.d.ts"
     }
   },
   "types": "./types/src/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,10 @@ import {
 } from "rxjs";
 import { webSocket } from "rxjs/webSocket";
 
-import { createEventByNip07, createEventBySecretKey } from "./nostr/event";
-import type { Nip07 } from "./nostr/nip07";
-import { Nostr } from "./nostr/primitive";
-import { completeOnTimeout } from "./operator";
+import { createEventByNip07, createEventBySecretKey } from "./nostr/event.js";
+import type { Nip07 } from "./nostr/nip07.js";
+import { Nostr } from "./nostr/primitive.js";
+import { completeOnTimeout } from "./operator.js";
 import type {
   ConnectionState,
   ConnectionStatePacket,
@@ -39,14 +39,14 @@ import type {
   EventPacket,
   MessagePacket,
   OkPacket,
-} from "./packet";
-import type { RxReq } from "./req";
-import { createSignal, defineDefaultOptions } from "./util";
+} from "./packet.js";
+import type { RxReq } from "./req.js";
+import { createSignal, defineDefaultOptions } from "./util.js";
 
-export * from "./nostr/primitive";
-export * from "./operator";
-export * from "./packet";
-export * from "./req";
+export * from "./nostr/primitive.js";
+export * from "./operator.js";
+export * from "./packet.js";
+export * from "./req.js";
 
 /**
  * The core object of rx-nostr, which holds a connection to relays

--- a/src/nostr/event.ts
+++ b/src/nostr/event.ts
@@ -2,8 +2,8 @@ import { schnorr } from "@noble/curves/secp256k1";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 
-import { toHex } from "./bech32";
-import { Nostr } from "./primitive";
+import { toHex } from "./bech32.js";
+import { Nostr } from "./primitive.js";
 
 const utf8Encoder = new TextEncoder();
 

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -15,9 +15,9 @@ import {
   TimeoutError,
 } from "rxjs";
 
-import { verify as _verify } from "./nostr/event";
-import { Nostr } from "./nostr/primitive";
-import { EventPacket } from "./packet";
+import { verify as _verify } from "./nostr/event.js";
+import { Nostr } from "./nostr/primitive.js";
+import { EventPacket } from "./packet.js";
 
 /**
  * Remove the events once seen.

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -1,4 +1,4 @@
-import { Nostr } from "./nostr/primitive";
+import { Nostr } from "./nostr/primitive.js";
 
 // Packet is data treated by rx-nostr Observables.
 

--- a/src/req.ts
+++ b/src/req.ts
@@ -1,8 +1,8 @@
 import { BehaviorSubject, Observable, OperatorFunction } from "rxjs";
 
-import { Nostr } from "./nostr/primitive";
-import { ReqPacket } from "./packet";
-import type { Override } from "./util";
+import { Nostr } from "./nostr/primitive.js";
+import { ReqPacket } from "./packet.js";
+import type { Override } from "./util.js";
 
 /**
  * The RxReq interface that is provided for RxNostr (not for users).

--- a/src/test/extend.test.ts
+++ b/src/test/extend.test.ts
@@ -1,4 +1,4 @@
-import { createRxBackwardReq, extend, mixin } from "../index";
+import { createRxBackwardReq, extend, mixin } from "../index.js";
 
 test("Extend req.", async () => {
   const addFoo = mixin<{ strategy: "backward" }, { foo: () => string }>(() => ({

--- a/src/test/mock-relay.ts
+++ b/src/test/mock-relay.ts
@@ -1,7 +1,7 @@
 import { WS } from "jest-websocket-mock";
 
-import { Nostr } from "../nostr/primitive";
-import { fakeEventMessage } from "./stub";
+import { Nostr } from "../nostr/primitive.js";
+import { fakeEventMessage } from "./stub.js";
 
 export function createMockRelay(url: string, interval = 10) {
   const server = new WS(url);

--- a/src/test/operator.test.ts
+++ b/src/test/operator.test.ts
@@ -1,9 +1,9 @@
 import { of } from "rxjs";
 
-import { latestEach } from "../operator";
-import { EventPacket } from "../packet";
-import { fakeEventPacket } from "./stub";
-import { asArray } from "./test-helper";
+import { latestEach } from "../operator.js";
+import { EventPacket } from "../packet.js";
+import { fakeEventPacket } from "./stub.js";
+import { asArray } from "./test-helper.js";
 
 test("latestEach()", async () => {
   const packet$ = of<EventPacket[]>(

--- a/src/test/strategy.test.ts
+++ b/src/test/strategy.test.ts
@@ -6,9 +6,9 @@ import {
   createRxNostr,
   createRxOneshotReq,
   RxNostr,
-} from "../index";
-import { createMockRelay, expectReceiveMessage } from "./mock-relay";
-import { asArray, sync } from "./test-helper";
+} from "../index.js";
+import { createMockRelay, expectReceiveMessage } from "./mock-relay.js";
+import { asArray, sync } from "./test-helper.js";
 
 describe("Single relay case", () => {
   const RELAY_URL = "ws://localhost:1234";

--- a/src/test/stub.ts
+++ b/src/test/stub.ts
@@ -1,5 +1,5 @@
-import { Nostr } from "../nostr/primitive";
-import { EventPacket } from "../packet";
+import { Nostr } from "../nostr/primitive.js";
+import { EventPacket } from "../packet.js";
 
 export function fakeEvent(event?: Partial<Nostr.Event>): Nostr.Event {
   return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
Fixed the following error that occurred when using `rx-nostr` in a project where `"moduleResolution": "NodeNext"` is specified in `tsconfig.json`.

```
TS7016: Could not find a declaration file for module 'rx-nostr'. '/Users/akiomi/src/github.com/akiomik/sample-project/node_modules/rx-nostr/dist/index.es.js' implicitly has an 'any' type.
  There are types at '/Users/akiomi/src/github.com/akiomik/sample-project/node_modules/rx-nostr/types/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'rx-nostr' library may need to update its package.json or typings.
```

ESM support for Jest is based on the following page.
- https://kulshekhar.github.io/ts-jest/docs/guides/esm-support