### PR TITLE
Change imports for supporting NodeNext

### DIFF
--- a/src/__test__/extend.test.ts
+++ b/src/__test__/extend.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 
-import { createRxBackwardReq, extend, mixin } from "../index";
+import { createRxBackwardReq, extend, mixin } from "../index.js";
 
 test("Extend req.", async () => {
   const addFoo = mixin<{ strategy: "backward" }, { foo: () => string }>(() => ({

--- a/src/__test__/helper.ts
+++ b/src/__test__/helper.ts
@@ -4,7 +4,7 @@ import { TestScheduler } from "rxjs/testing";
 import { expect } from "vitest";
 import { createClientSpy, faker as _faker } from "vitest-nostr";
 
-import { EventPacket, MessagePacket } from "../packet";
+import { EventPacket, MessagePacket } from "../packet.js";
 
 export function testScheduler() {
   return new TestScheduler((a, b) => expect(a).toEqual(b));

--- a/src/__test__/operator.test.ts
+++ b/src/__test__/operator.test.ts
@@ -1,9 +1,9 @@
 import { map, of } from "rxjs";
 import { test } from "vitest";
 
-import { filterType, latestEach } from "../operator";
-import { EventPacket, MessagePacket } from "../packet";
-import { faker, testScheduler } from "./helper";
+import { filterType, latestEach } from "../operator.js";
+import { EventPacket, MessagePacket } from "../packet.js";
+import { faker, testScheduler } from "./helper.js";
 
 test("latestEach()", async () => {
   testScheduler().run((helpers) => {

--- a/src/__test__/sending.test.ts
+++ b/src/__test__/sending.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { createMockRelay, type MockRelay } from "vitest-nostr";
 
-import { createRxNostr, RxNostr } from "..";
-import { WebSocketCloseCode } from "../connection";
-import { faker, spySub } from "./helper";
+import { WebSocketCloseCode } from "../connection.js";
+import { createRxNostr, RxNostr } from "../index.js";
+import { faker, spySub } from "./helper.js";
 
 describe("Basic sending behavior", () => {
   const RELAY_URL1 = "ws://localhost:1234";

--- a/src/__test__/subscription.test.ts
+++ b/src/__test__/subscription.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, assert, beforeEach, describe, expect, test } from "vitest";
 import { createMockRelay, type MockRelay } from "vitest-nostr";
 
+import { WebSocketCloseCode } from "../connection.js";
 import {
   createRxBackwardReq,
   createRxForwardReq,
   createRxNostr,
   createRxOneshotReq,
   RxNostr,
-} from "..";
-import { WebSocketCloseCode } from "../connection";
-import { faker, spyEvent, spySub } from "./helper";
+} from "../index.js";
+import { faker, spyEvent, spySub } from "./helper.js";
 
 describe("Basic subscription behavior (single relay)", () => {
   const RELAY_URL = "ws://localhost:1234";

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -14,9 +14,9 @@ import {
   timer,
 } from "rxjs";
 
-import { evalFilters } from "./helper";
-import { isFiltered } from "./nostr/filter";
-import { ConnectionState, LazyREQ, MessagePacket } from "./packet";
+import { evalFilters } from "./helper.js";
+import { isFiltered } from "./nostr/filter.js";
+import { ConnectionState, LazyREQ, MessagePacket } from "./packet.js";
 
 export class Connection {
   private socket: WebSocket | null = null;

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -1,7 +1,7 @@
 /** Return a function that is lazily evaluated for since/until parameters of `LazyFilter`. */
 import Nostr from "nostr-typedef";
 
-import { LazyFilter } from "./packet";
+import { LazyFilter } from "./packet.js";
 
 export function now(): number {
   return Math.floor(new Date().getTime() / 1000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export * from "./helper";
-export { toHex } from "./nostr/bech32";
+export * from "./helper.js";
+export { toHex } from "./nostr/bech32.js";
 export {
   compareEvents,
   earlierEvent,
@@ -8,10 +8,10 @@ export {
   getSignature,
   getSignedEvent,
   laterEvent,
-} from "./nostr/event";
-export { isFiltered } from "./nostr/filter";
-export { fetchRelayInfo } from "./nostr/nip11";
-export * from "./operator";
-export * from "./packet";
-export * from "./req";
-export * from "./rx-nostr";
+} from "./nostr/event.js";
+export { isFiltered } from "./nostr/filter.js";
+export { fetchRelayInfo } from "./nostr/nip11.js";
+export * from "./operator.js";
+export * from "./packet.js";
+export * from "./req.js";
+export * from "./rx-nostr.js";

--- a/src/nostr/event.ts
+++ b/src/nostr/event.ts
@@ -3,7 +3,7 @@ import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import Nostr from "nostr-typedef";
 
-import { toHex } from "./bech32";
+import { toHex } from "./bech32.js";
 
 const utf8Encoder = new TextEncoder();
 

--- a/src/nostr/filter.ts
+++ b/src/nostr/filter.ts
@@ -1,6 +1,6 @@
 import * as Nostr from "nostr-typedef";
 
-import { defineDefaultOptions } from "../util";
+import { defineDefaultOptions } from "../util.js";
 
 export interface MatchFilterOptions {
   sinceInclusive: boolean;

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -19,12 +19,12 @@ import {
   TimeoutError,
 } from "rxjs";
 
-import { evalFilters } from "./helper";
-import { compareEvents, verify as _verify } from "./nostr/event";
-import { isFiltered } from "./nostr/filter";
-import { MatchFilterOptions } from "./nostr/filter";
-import { EventPacket, LazyFilter, MessagePacket, ReqPacket } from "./packet";
-import { defineDefaultOptions } from "./util";
+import { evalFilters } from "./helper.js";
+import { compareEvents, verify as _verify } from "./nostr/event.js";
+import { isFiltered } from "./nostr/filter.js";
+import { MatchFilterOptions } from "./nostr/filter.js";
+import { EventPacket, LazyFilter, MessagePacket, ReqPacket } from "./packet.js";
+import { defineDefaultOptions } from "./util.js";
 
 // --------------------- //
 // EventPacket operators //

--- a/src/req.ts
+++ b/src/req.ts
@@ -1,8 +1,8 @@
 import Nostr from "nostr-typedef";
 import { BehaviorSubject, Observable, OperatorFunction } from "rxjs";
 
-import { LazyFilter, ReqPacket } from "./packet";
-import type { Override } from "./util";
+import { LazyFilter, ReqPacket } from "./packet.js";
+import type { Override } from "./util.js";
 
 /**
  * The RxReq interface that is provided for RxNostr (**not for users**).

--- a/src/rx-nostr.ts
+++ b/src/rx-nostr.ts
@@ -24,10 +24,10 @@ import {
   Unsubscribable,
 } from "rxjs";
 
-import { BackoffConfig, Connection } from "./connection";
-import { getSignedEvent } from "./nostr/event";
-import { fetchRelayInfo } from "./nostr/nip11";
-import { completeOnTimeout } from "./operator";
+import { BackoffConfig, Connection } from "./connection.js";
+import { getSignedEvent } from "./nostr/event.js";
+import { fetchRelayInfo } from "./nostr/nip11.js";
+import { completeOnTimeout } from "./operator.js";
 import type {
   ConnectionState,
   ConnectionStatePacket,
@@ -37,9 +37,9 @@ import type {
   LazyREQ,
   MessagePacket,
   OkPacket,
-} from "./packet";
-import type { RxReq } from "./req";
-import { defineDefaultOptions, normalizeRelayUrl } from "./util";
+} from "./packet.js";
+import type { RxReq } from "./req.js";
+import { defineDefaultOptions, normalizeRelayUrl } from "./util.js";
 
 /**
  * The core object of rx-nostr, which holds a connection to relays


### PR DESCRIPTION
When a dependent sets `"module": "NodeNext"` in `tsconfig.json`, the types cannot be resolved, so I fixed the `import` directives.　