### PR TITLE
feat: REQ queue

### DIFF
--- a/src/__test__/subscription.test.ts
+++ b/src/__test__/subscription.test.ts
@@ -21,6 +21,9 @@ describe("Basic subscription behavior (single relay)", () => {
 
     rxNostr = createRxNostr({
       retry: { strategy: "immediately", maxCount: 1 },
+      globalRelayConfig: {
+        disableAutoFetchNip11Limitations: true,
+      },
     });
     await rxNostr.switchRelays([RELAY_URL]);
 
@@ -316,7 +319,11 @@ describe("Basic subscription behavior (multiple relays)", () => {
     relay2 = createMockRelay(RELAY_URL2);
     relay3 = createMockRelay(RELAY_URL3);
 
-    rxNostr = createRxNostr();
+    rxNostr = createRxNostr({
+      globalRelayConfig: {
+        disableAutoFetchNip11Limitations: true,
+      },
+    });
     await rxNostr.switchRelays([RELAY_URL1, RELAY_URL2]);
 
     await relay1.connected;

--- a/src/rx-nostr.ts
+++ b/src/rx-nostr.ts
@@ -213,7 +213,6 @@ export interface RelayConfig {
   /** If true, rxNostr can send EVENTs. */
   write: boolean;
   disableAutoFetchNip11Limitations?: boolean;
-  maxConcurrentReqsFallback?: number;
 }
 
 /** Parameter of `rxNostr.switchRelays()` */
@@ -284,7 +283,6 @@ class RxNostrImpl implements RxNostr {
     read,
     write,
     disableAutoFetchNip11Limitations,
-    maxConcurrentReqsFallback,
   }: RelayConfig): Connection {
     const connection = new Connection(url, {
       backoff: this.options.retry,
@@ -294,7 +292,6 @@ class RxNostrImpl implements RxNostr {
         disableAutoFetchNip11Limitations ??
         this.options.globalRelayConfig?.disableAutoFetchNip11Limitations,
       maxConcurrentReqsFallback:
-        maxConcurrentReqsFallback ??
         this.options.globalRelayConfig?.maxConcurrentReqsFallback,
     });
 

--- a/src/rx-nostr.ts
+++ b/src/rx-nostr.ts
@@ -685,10 +685,19 @@ class RxNostrImpl implements RxNostr {
     }
 
     if (url) {
-      this.connections.get(url)?.finalizeReq(subId);
+      const conn = this.connections.get(url);
+      if (subId) {
+        conn?.finalizeReq(subId);
+      } else {
+        conn?.finalizeAllReqs();
+      }
     } else {
       for (const conn of this.connections.values()) {
-        conn.finalizeReq(subId);
+        if (subId) {
+          conn?.finalizeReq(subId);
+        } else {
+          conn?.finalizeAllReqs();
+        }
       }
     }
   }


### PR DESCRIPTION
resolve #27

- The number of concurrent REQs on a relay is suppressed based on auto-fetched NIP-11 information or a given fallback value (`maxConcurrentReqsFallback`).
- `disableAutoFetchNip11Limitations` disables automatically NIP-11 fetching.