### PR TITLE
Fix a problem when bundled with Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "types": "./types/src/index.d.ts",
   "exports": {
     ".": {
+      "module": "./dist/index.es.js",
       "import": "./dist/index.es.js",
       "require": "./dist/index.umd.js",
       "types": "./types/src/index.d.ts"


### PR DESCRIPTION
When rx-nostr gets bundled with Webpack, calling functions of rx-nostr (to say, `createRxNostr`) cause the error: `Uncaught TypeError: createRxNostr is not a function`.

Minimum reproduction process: https://github.com/jiftechnify/rx-nostr-with-webpack-bug-reprod

Adding the `"module"` key to the conditional exports seems to fix the issue. 