### PR TITLE
fix: improve performance

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -4,7 +4,7 @@ import Nostr from "nostr-typedef";
 import { LazyFilter } from "./packet.js";
 
 export function now(): number {
-  return Math.floor(new Date().getTime() / 1000);
+  return Math.floor(Date.now() / 1000);
 }
 
 export function evalFilters(

--- a/src/nostr/event.ts
+++ b/src/nostr/event.ts
@@ -19,7 +19,7 @@ export async function getSignedEvent(
     ...params,
     pubkey: params.pubkey ?? (await getPubkey()),
     tags: params.tags ?? [],
-    created_at: params.created_at ?? Math.floor(new Date().getTime() / 1000),
+    created_at: params.created_at ?? Math.floor(Date.now() / 1000),
   };
 
   if (ensureRequiredFields(params)) {


### PR DESCRIPTION
before:
```
> console.time(); for (let i = 0; i < 100000; i++) { new Date().getTime(); } console.timeEnd();
VM551:1 default: 17.94189453125 ms
```

after:
```
> console.time(); for (let i = 0; i < 100000; i++) { Date.now() } console.timeEnd();
VM557:1 default: 8.649169921875 ms
```