### PR TITLE
feat: add alias fields in MessagePackets

### DIFF
--- a/src/connection/subscribe.ts
+++ b/src/connection/subscribe.ts
@@ -7,7 +7,7 @@ import { Nip11Registry } from "../nip11.js";
 import { verify } from "../nostr/event.js";
 import { isFiltered } from "../nostr/filter.js";
 import { isExpired } from "../nostr/nip40.js";
-import { LazyREQ } from "../packet.js";
+import { EventPacket, LazyREQ } from "../packet.js";
 import { RelayConnection } from "./relay.js";
 import { CounterSubject } from "./utils.js";
 
@@ -37,7 +37,7 @@ export class SubscribeProxy {
     });
 
     // Auto closing
-    this.relay.getEOSEObservable().subscribe(([, subId]) => {
+    this.relay.getEOSEObservable().subscribe(({ subId }) => {
       if (this.subs.get(subId)?.autoclose) {
         this.unsubscribe(subId);
       }
@@ -75,9 +75,9 @@ export class SubscribeProxy {
     return this.queue.has(subId);
   }
 
-  getEventObservable(): Observable<Nostr.ToClientMessage.EVENT> {
+  getEventObservable(): Observable<EventPacket> {
     return this.relay.getEVENTObservable().pipe(
-      filter(([, subId, event]) => {
+      filter(({ subId, event }) => {
         const filters = this.subs.get(subId)?.filters;
         if (!filters) {
           return false;

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -182,17 +182,20 @@ export function dropExpiredEvents(
 
 export function filterByType<T extends Nostr.ToClientMessage.Type>(
   type: T
-): OperatorFunction<
-  MessagePacket,
-  MessagePacket<Nostr.ToClientMessage.Message<T>>
-> {
+): OperatorFunction<MessagePacket, MessagePacket & { type: T }> {
   return filter(
-    (packet): packet is MessagePacket<Nostr.ToClientMessage.Message<T>> =>
+    (packet): packet is MessagePacket & { type: T } =>
       packet.message[0] === type
   );
 }
 /** @deprecated Renamed. Use `filterByType` instead. */
 export const filterType = filterByType;
+
+export function filterBySubId<P extends MessagePacket & { subId: string }>(
+  subId: string
+): OperatorFunction<P, P> {
+  return filter((packet) => packet.subId === subId);
+}
 
 // ------------------- //
 // ReqPacket operators //

--- a/src/packet.ts
+++ b/src/packet.ts
@@ -21,12 +21,58 @@ export type LazyFilter = Omit<Nostr.Filter, "since" | "until"> & {
 export type LazyREQ = ["REQ", string, ...LazyFilter[]];
 
 /**
+ * Packets from websocket that represents all raw incoming messages.
+ */
+export type MessagePacket =
+  | EventPacket
+  | EosePacket
+  | OkPacket
+  | NoticePacket
+  | AuthPacket
+  | CountPacket;
+
+export interface MessagePacketBase<
+  T extends Nostr.ToClientMessage.Type = Nostr.ToClientMessage.Type
+> {
+  from: string;
+  type: T;
+  message: Nostr.ToClientMessage.Message<T>;
+}
+
+/**
  * Packets from websocket that represents an EVENT.
  */
-export interface EventPacket {
-  from: string;
+export interface EventPacket extends MessagePacketBase<"EVENT"> {
   subId: string;
   event: Nostr.Event;
+}
+
+export interface EosePacket extends MessagePacketBase<"EOSE"> {
+  subId: string;
+}
+
+/**
+ * Packets represents OK messages associated with an EVENT submission.
+ */
+export interface OkPacket extends MessagePacketBase<"OK"> {
+  /** @deprecated Use `eventId` instead. */
+  id: string;
+  eventId: string;
+  ok: boolean;
+  notice?: string;
+}
+
+export interface NoticePacket extends MessagePacketBase<"NOTICE"> {
+  notice: string;
+}
+
+export interface AuthPacket extends MessagePacketBase<"AUTH"> {
+  challengeMessage: string;
+}
+
+export interface CountPacket extends MessagePacketBase<"COUNT"> {
+  subId: string;
+  count: Nostr.ToClientMessage.CountResponse;
 }
 
 /**
@@ -35,16 +81,6 @@ export interface EventPacket {
 export interface ErrorPacket {
   from: string;
   reason: unknown;
-}
-
-/**
- * Packets from websocket that represents all raw incoming messages.
- */
-export interface MessagePacket<
-  M extends Nostr.ToClientMessage.Any = Nostr.ToClientMessage.Any
-> {
-  from: string;
-  message: M;
 }
 
 /**
@@ -78,12 +114,3 @@ export type ConnectionState =
   | "error"
   | "rejected"
   | "terminated";
-
-/**
- * Packets represents OK messages associated with an EVENT submission.
- */
-export interface OkPacket {
-  from: string;
-  id: string;
-  ok: boolean;
-}

--- a/src/rx-nostr/utils.ts
+++ b/src/rx-nostr/utils.ts
@@ -1,12 +1,6 @@
-import Nostr from "nostr-typedef";
-import { filter, map, type OperatorFunction, pipe } from "rxjs";
+import { filter, type OperatorFunction } from "rxjs";
 
-import type {
-  EventPacket,
-  LazyFilter,
-  LazyREQ,
-  MessagePacket,
-} from "../packet.js";
+import type { LazyFilter, LazyREQ, MessagePacket } from "../packet.js";
 import type { RxReq } from "../req.js";
 import type {
   AcceptableDefaultRelaysConfig,
@@ -30,19 +24,6 @@ export function makeLazyREQ(params: {
   const { rxReq, filters, index } = params;
 
   return ["REQ", makeSubId({ rxReq, index }), ...filters];
-}
-
-export function pickEvent(
-  subId: string
-): OperatorFunction<MessagePacket<Nostr.ToClientMessage.EVENT>, EventPacket> {
-  return pipe(
-    filter(({ message }) => message[1] === subId),
-    map(({ from, message }) => ({
-      from,
-      subId: message[1],
-      event: message[2],
-    }))
-  );
 }
 
 export function normalizeRelaysConfig(


### PR DESCRIPTION
All `MessagePacket`s are now [discriminated union](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions). This makes `createAllMessageObservable()` easier to use.

They still contain the `from` and `message` fields, but now also have a common `type` (`"EVENT" | "EOSE" | "OK" | ...`) field and an additional alias field for each `type` to access each element of the `message` tuple.

```ts
rxNostr.createAllMessageObservable().subscribe((packet) => {
  if (packet.type === "NOTICE") {
    // TypeScript does not complain about this
    console.log(packet.notice); // is equivalent to packet.message[1]
  }
});

// In above case, `filterByType()` also works well
rxNostr
  .createAllMessageObservable()
  .pipe(filterByType("NOTICE"))
  .subscribe((packet) => {
    console.log(packet.notice);
  });
```