### PR TITLE
Fix docs

### DIFF
--- a/packages/docs/en/v2/auth.md
+++ b/packages/docs/en/v2/auth.md
@@ -13,12 +13,12 @@ const rxNostr = createRxNostr({ authenticator: "auto" });
 For more advanced use cases, the `authenticator` can optionally take a `signer`. This allows the AUTH message to be created using a different signer than when issuing normal events:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr, seckeySigner } from "rx-nostr";
 
 const rxNostr = createRxNostr({
-  signer: nsecSigner("nsec1aaa..."),
+  signer: seckeySigner("nsec1aaa..."),
   authenticator: {
-    signer: nsecSigner("nsec1bbb..."),
+    signer: seckeySigner("nsec1bbb..."),
   },
 });
 ```
@@ -26,7 +26,7 @@ const rxNostr = createRxNostr({
 It is also possible to specify a function format in case you want to use a different signer for each relay. For example, the following example responds to AUTH messages only on `wss://nostr.example.com` and ignores AUTH on other relays:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr } from "rx-nostr";
 
 const rxNostr = createRxNostr({
   authenticator: (relayUrl) => {

--- a/packages/docs/en/v2/delegation.md
+++ b/packages/docs/en/v2/delegation.md
@@ -7,7 +7,7 @@ rx-nostr supports event delegation based on [NIP-26](https://github.com/nostr-pr
 You can use `delegateSigner()` to issue delegated events.
 
 ```ts
-import { delegateSigner, nsecSigner } from "rx-nostr";
+import { delegateSigner, seckeySigner } from "rx-nostr";
 
 const signer = delegateSigner({
   delegateeSigner: seckeySigner(seckeyChild),

--- a/packages/docs/en/v2/other-observables.md
+++ b/packages/docs/en/v2/other-observables.md
@@ -10,9 +10,9 @@ These are all Observable of RxJS. They are not completed until `rxNostr.dispose(
 
 `rxNostr.createAllMessageObservable()` allows you to observe all incoming messages (including unknown type messages).
 
-## createAllMessageObservable()
+## createAllEventObservable()
 
-`rxNostr.createAllMessageObservable()` allows you to observe all EVENT message.
+`rxNostr.createAllEventObservable()` allows you to observe all EVENT message.
 
 ## createAllErrorObservable()
 

--- a/packages/docs/en/v3/auth.md
+++ b/packages/docs/en/v3/auth.md
@@ -13,12 +13,13 @@ const rxNostr = createRxNostr({ authenticator: "auto" });
 For more advanced use cases, the `authenticator` can optionally take a `signer`. This allows the AUTH message to be created using a different signer than when issuing normal events:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr } from "rx-nostr";
+import { seckeySigner } from "rx-nostr-crypto";
 
 const rxNostr = createRxNostr({
-  signer: nsecSigner("nsec1aaa..."),
+  signer: seckeySigner("nsec1aaa..."),
   authenticator: {
-    signer: nsecSigner("nsec1bbb..."),
+    signer: seckeySigner("nsec1bbb..."),
   },
 });
 ```
@@ -26,7 +27,7 @@ const rxNostr = createRxNostr({
 It is also possible to specify a function format in case you want to use a different signer for each relay. For example, the following example responds to AUTH messages only on `wss://nostr.example.com` and ignores AUTH on other relays:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr } from "rx-nostr";
 
 const rxNostr = createRxNostr({
   authenticator: (relayUrl) => {

--- a/packages/docs/en/v3/dispose.md
+++ b/packages/docs/en/v3/dispose.md
@@ -1,6 +1,6 @@
 # Dispose
 
-`RxNostr` and `VerificationServiceClient` (See [Verifier](./verifier)) are `dispose()`-able object。`dispose()`-able objects should be `dispose()`'d when they get to be no longer used.
+`RxNostr` and `VerificationServiceClient` (See [Verifier](./verifier)) are `dispose()`-able object. `dispose()`-able objects should be `dispose()`'d when they get to be no longer used.
 
 `dispose()` releases all resource and makes the object unavailable. In `RxNostr` case, it closes all WebSocket connection immediately.
 

--- a/packages/docs/en/v3/other-observables.md
+++ b/packages/docs/en/v3/other-observables.md
@@ -10,9 +10,9 @@ These are all Observable of RxJS. They are not completed until `rxNostr.dispose(
 
 `rxNostr.createAllMessageObservable()` allows you to observe all incoming messages (including unknown type messages).
 
-## createAllMessageObservable()
+## createAllEventObservable()
 
-`rxNostr.createAllMessageObservable()` allows you to observe all EVENT message.
+`rxNostr.createAllEventObservable()` allows you to observe all EVENT message.
 
 ## createAllErrorObservable()
 

--- a/packages/docs/ja/v2/auth.md
+++ b/packages/docs/ja/v2/auth.md
@@ -13,12 +13,12 @@ const rxNostr = createRxNostr({ authenticator: "auto" });
 より高度なユースケースに対応するため、`authenticator` は `signer` をオプションに取ることができます。これにより、通常のイベント発行時とは異なる署名器を用いて AUTH メッセージを作成できます:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr, seckeySigner } from "rx-nostr";
 
 const rxNostr = createRxNostr({
-  signer: nsecSigner("nsec1aaa..."),
+  signer: seckeySigner("nsec1aaa..."),
   authenticator: {
-    signer: nsecSigner("nsec1bbb..."),
+    signer: seckeySigner("nsec1bbb..."),
   },
 });
 ```
@@ -26,7 +26,7 @@ const rxNostr = createRxNostr({
 また、リレーごとに異なる署名器を使いたい場合のために、関数形式の指定も可能です。例えば以下の例では、`wss://nostr.example.com` でのみ AUTH メッセージに応答し、他のリレーでは AUTH を無視します:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr } from "rx-nostr";
 
 const rxNostr = createRxNostr({
   authenticator: (relayUrl) => {

--- a/packages/docs/ja/v2/delegation.md
+++ b/packages/docs/ja/v2/delegation.md
@@ -7,7 +7,7 @@ rx-nostr は [NIP-26](https://github.com/nostr-protocol/nips/blob/master/26.md) 
 `delegateSigner()` を利用すると委任されたイベントを発行できます。
 
 ```ts
-import { delegateSigner, nsecSigner } from "rx-nostr";
+import { delegateSigner, seckeySigner } from "rx-nostr";
 
 const signer = delegateSigner({
   delegateeSigner: seckeySigner(seckeyChild),

--- a/packages/docs/ja/v2/other-observables.md
+++ b/packages/docs/ja/v2/other-observables.md
@@ -10,9 +10,9 @@ rx-nostr には他にもいくつか `subscribe()` 可能なオブジェクト�
 
 `rxNostr.createAllMessageObservable()` によって、リレーから送られてきた (未知のタイプのメッセージを含む) すべてのメッセージを監視できます。
 
-## createAllMessageObservable()
+## createAllEventObservable()
 
-`rxNostr.createAllMessageObservable()` によって、リレーから送られてきたすべての EVENT メッセージを監視できます。
+`rxNostr.createAllEventObservable()` によって、リレーから送られてきたすべての EVENT メッセージを監視できます。
 
 ## createAllErrorObservable()
 

--- a/packages/docs/ja/v3/auth.md
+++ b/packages/docs/ja/v3/auth.md
@@ -13,12 +13,13 @@ const rxNostr = createRxNostr({ authenticator: "auto" });
 より高度なユースケースに対応するため、`authenticator` は `signer` をオプションに取ることができます。これにより、通常のイベント発行時とは異なる署名器を用いて AUTH メッセージを作成できます:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr } from "rx-nostr";
+import { seckeySigner } from "rx-nostr-crypto";
 
 const rxNostr = createRxNostr({
-  signer: nsecSigner("nsec1aaa..."),
+  signer: seckeySigner("nsec1aaa..."),
   authenticator: {
-    signer: nsecSigner("nsec1bbb..."),
+    signer: seckeySigner("nsec1bbb..."),
   },
 });
 ```
@@ -26,7 +27,7 @@ const rxNostr = createRxNostr({
 また、リレーごとに異なる署名器を使いたい場合のために、関数形式の指定も可能です。例えば以下の例では、`wss://nostr.example.com` でのみ AUTH メッセージに応答し、他のリレーでは AUTH を無視します:
 
 ```ts:line-numbers
-import { createRxNostr, nsecSigner } from "rx-nostr";
+import { createRxNostr } from "rx-nostr";
 
 const rxNostr = createRxNostr({
   authenticator: (relayUrl) => {

--- a/packages/docs/ja/v3/other-observables.md
+++ b/packages/docs/ja/v3/other-observables.md
@@ -10,9 +10,9 @@ rx-nostr には他にもいくつか `subscribe()` 可能なオブジェクト�
 
 `rxNostr.createAllMessageObservable()` によって、リレーから送られてきた (未知のタイプのメッセージを含む) すべてのメッセージを監視できます。
 
-## createAllMessageObservable()
+## createAllEventObservable()
 
-`rxNostr.createAllMessageObservable()` によって、リレーから送られてきたすべての EVENT メッセージを監視できます。
+`rxNostr.createAllEventObservable()` によって、リレーから送られてきたすべての EVENT メッセージを監視できます。
 
 ## createAllErrorObservable()
 


### PR DESCRIPTION
Summary of errors in the docs:
- `nsecSigner` doesn't exist. You mean `seckeySigner`?
- `seckeySigner` should be imported from `rx-nostr-crypto` in v3
- Duplicated sections for `createAllMessageObservable()`. The description in the latter section seems like for `createAllEventObservable()`
- 「。」in a English doc