### PR TITLE
fix: ERR_REQUIRE_ESM error under CommonJS module system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6334,7 +6334,7 @@
     },
     "packages/core": {
       "name": "rx-nostr",
-      "version": "3.3.4",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "nostr-typedef": "^0.9.0",

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = require('./dist/index.cjs')
+module.exports = require('./dist/rx-nostr.cjs')

--- a/packages/core/index.cjs
+++ b/packages/core/index.cjs
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./dist/index.cjs')

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = require('./dist/index.cjs.js')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,19 +14,19 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "index.js",
-  "module": "./dist/index.es.js",
-  "types": "./dist/index.d.ts",
+  "main": "./index.cjs",
+  "module": "./dist/rx-nostr.js",
+  "types": "./dist/rx-nostr.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.es.js"
+        "types": "./dist/rx-nostr.d.ts",
+        "default": "./dist/rx-nostr.js"
       },
       "require": {
-        "types": "./dist/index.d.ts",
-        "node": "./dist/index.cjs.js",
-        "default": "./dist/index.umd.js"
+        "types": "./dist/rx-nostr.d.ts",
+        "node": "./dist/rx-nostr.cjs",
+        "default": "./dist/rx-nostr.umd.cjs"
       }
     },
     "./src": "./src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,15 +16,15 @@
   "type": "module",
   "main": "./index.cjs",
   "module": "./dist/rx-nostr.js",
-  "types": "./dist/rx-nostr.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/rx-nostr.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/rx-nostr.js"
       },
       "require": {
-        "types": "./dist/rx-nostr.d.ts",
+        "types": "./dist/index.d.ts",
         "node": "./dist/rx-nostr.cjs",
         "default": "./dist/rx-nostr.umd.cjs"
       }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   build: {
     lib: {
       name: "rx-nostr",
-      fileName: (format) => `index.${format}.js`,
       entry: path.resolve(__dirname, "src/index.ts"),
       formats: ["es", "cjs", "umd"],
     },

--- a/packages/crypto/index.cjs
+++ b/packages/crypto/index.cjs
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('./dist/index.cjs')

--- a/packages/crypto/index.cjs
+++ b/packages/crypto/index.cjs
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = require('./dist/index.cjs')
+module.exports = require('./dist/rx-nostr-crypto.cjs')

--- a/packages/crypto/index.js
+++ b/packages/crypto/index.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = require('./dist/index.cjs.js')

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -13,15 +13,15 @@
   "type": "module",
   "main": "./index.cjs",
   "module": "./dist/rx-nostr-crypto.js",
-  "types": "./dist/rx-nostr-crypto.d.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/rx-nostr-crypto.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/rx-nostr-crypto.js"
       },
       "require": {
-        "types": "./dist/rx-nostr-crypto.d.ts",
+        "types": "./dist/index.d.ts",
         "node": "./dist/rx-nostr-crypto.cjs",
         "default": "./dist/rx-nostr-crypto.umd.cjs"
       }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -11,19 +11,19 @@
   },
   "license": "MIT",
   "type": "module",
-  "main": "index.js",
-  "module": "./dist/index.es.js",
-  "types": "./dist/index.d.ts",
+  "main": "./index.cjs",
+  "module": "./dist/rx-nostr-crypto.js",
+  "types": "./dist/rx-nostr-crypto.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.es.js"
+        "types": "./dist/rx-nostr-crypto.d.ts",
+        "default": "./dist/rx-nostr-crypto.js"
       },
       "require": {
-        "types": "./dist/index.d.ts",
-        "node": "./dist/index.cjs.js",
-        "default": "./dist/index.umd.js"
+        "types": "./dist/rx-nostr-crypto.d.ts",
+        "node": "./dist/rx-nostr-crypto.cjs",
+        "default": "./dist/rx-nostr-crypto.umd.cjs"
       }
     },
     "./src": "./src/index.ts",

--- a/packages/crypto/vite.config.ts
+++ b/packages/crypto/vite.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   build: {
     lib: {
       name: "rx-nostr-crypto",
-      fileName: (format) => `index.${format}.js`,
       entry: path.resolve(__dirname, "src/index.ts"),
       formats: ["es", "cjs", "umd"],
     },


### PR DESCRIPTION
This PR removes the explicit `.js` file extension set in `vite.config.ts`. This was causing issues when using the package with node because node will treat any `.js` file in a package as an ES module if the `"type": "module"` is set

This was only an issue when importing the package from a CJS context. for example
```js
const {createRxNostr} = require("rx-nostr")
```

Would throw

```
/tmp/tmp.sesywPGnIr/test.cjs:1
const {createRxNostr} = require('rx-nostr')
                        ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /tmp/tmp.sesywPGnIr/node_modules/.pnpm/rx-nostr@3.4.1/node_modules/rx-nostr/dist/index.cjs.js from /tmp/tmp.sesywPGnIr/test.cjs not supported.
index.cjs.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead either rename index.cjs.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /tmp/tmp.sesywPGnIr/node_modules/.pnpm/rx-nostr@3.4.1/node_modules/rx-nostr/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).

    at Object.<anonymous> (/tmp/tmp.sesywPGnIr/test.cjs:1:25) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.18.1
```

To fix this I removed the `fileName` option in the `vite.config.ts` which makes vite use the default `.cjs` and `.mjs` file extensions.

So now its possible to import the package with `import` or `require`

```js
import { createRxNostr } from "rx-nostr"

const rxNostr = createRxNostr({})
console.log(rxNostr)
```

```js
const { createRxNostr } = require('rx-nostr')

const rxNostr = createRxNostr({})
console.log(rxNostr)
```