### PR TITLE
fix: export of emptyVerifier

### DIFF
--- a/packages/docs/en/v2/nip11-registry.md
+++ b/packages/docs/en/v2/nip11-registry.md
@@ -14,7 +14,7 @@ The NIP-11 information handled by rx-nostr is aggregated in `Nip11Registry`. The
 
 ## Fetch NIP-11 info manually
 
-You can maually fetch NIP-11 information by `Nip11Registry.fetch()`. Once NIP-11 fetched like this, rx-nostr can use the information to optimize its behavior even if `skipFetchNip11` is set.
+You can manually fetch NIP-11 information by `Nip11Registry.fetch()`. Once NIP-11 fetched like this, rx-nostr can use the information to optimize its behavior even if `skipFetchNip11` is set.
 
 ## Set Default NIP-11 info
 

--- a/packages/docs/en/v3/nip11-registry.md
+++ b/packages/docs/en/v3/nip11-registry.md
@@ -14,7 +14,7 @@ The NIP-11 information handled by rx-nostr is aggregated in `Nip11Registry`. The
 
 ## Fetch NIP-11 info manually
 
-You can maually fetch NIP-11 information by `Nip11Registry.fetch()`. Once NIP-11 fetched like this, rx-nostr can use the information to optimize its behavior even if `skipFetchNip11` is set.
+You can manually fetch NIP-11 information by `Nip11Registry.fetch()`. Once NIP-11 fetched like this, rx-nostr can use the information to optimize its behavior even if `skipFetchNip11` is set.
 
 ## Set Default NIP-11 info
 

--- a/packages/rx-nostr/src/index.ts
+++ b/packages/rx-nostr/src/index.ts
@@ -1,5 +1,10 @@
 export type * from "./config/index.js";
-export { nip07Signer, noopSigner, noopVerifier } from "./config/index.js";
+export {
+  emptyVerifier,
+  nip07Signer,
+  noopSigner,
+  noopVerifier,
+} from "./config/index.js";
 export * from "./error.js";
 export * from "./lazy-filter.js";
 export { Nip11Registry } from "./nip11.js";


### PR DESCRIPTION
`send` しか使わないときに `verifier` に（例外が投げられる） `emptyVerifier` を利用したい。