### PR TITLE
chore: stop minifying

### DIFF
--- a/packages/crypto/vite.config.ts
+++ b/packages/crypto/vite.config.ts
@@ -4,6 +4,7 @@ import dts from "vite-plugin-dts";
 
 export default defineConfig({
   build: {
+    minify: false,
     lib: {
       name: "rx-nostr-crypto",
       entry: path.resolve(__dirname, "src/index.ts"),

--- a/packages/rx-nostr/vite.config.ts
+++ b/packages/rx-nostr/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "import.meta.vitest": "undefined",
   },
   build: {
+    minify: false,
     lib: {
       name: "rx-nostr",
       entry: path.resolve(__dirname, "src/index.ts"),


### PR DESCRIPTION
In modern web development, minifying npm packages is considered an anti-pattern for the following reasons:

* Unminified code allows consumers' bundlers (Vite, Webpack, etc.) to analyze the code structure more effectively and remove unused exports.
* Provides clearer stack traces and easier inspection for developers using this library.

ref.
* https://stackoverflow.com/questions/48673408/should-javascript-npm-packages-be-minified
* https://gist.github.com/joepie91/04cc8329df231ea3e262dffe3d41f848