### PR TITLE
fix: prevent unexpected throws from some WebSocket implementation

### DIFF
--- a/packages/rx-nostr/src/connection/relay.ts
+++ b/packages/rx-nostr/src/connection/relay.ts
@@ -234,6 +234,9 @@ export class RelayConnection {
     socket?.addEventListener("open", onopen);
     socket?.addEventListener("message", onmessage);
     socket?.addEventListener("close", onclose);
+    // Some implementation(e.g. `ws`) throws if an "error" event has no listener.
+    // Attach a no-op handler to suppress that behavior.
+    socket?.addEventListener("error", () => {});
 
     return socket;
   }


### PR DESCRIPTION
In some implementations(I only know of `ws`), throws when no "error" event listener is attached.
This PR introduce workaround for prevent this behavior.