### PR TITLE
Fix publish state cleanup after OK

### DIFF
--- a/packages/rx-nostr/src/__test__/publish-state-cleanup.test.ts
+++ b/packages/rx-nostr/src/__test__/publish-state-cleanup.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { createMockRelay, type MockRelay } from "vitest-nostr";
+
+import { createRxNostr, noopVerifier, RxNostr } from "../index.js";
+import {
+  disposeMockRelay,
+  faker,
+  spySubscription,
+  stateWillBe,
+} from "./helper.js";
+
+const RELAY_URL = "ws://localhost:1234";
+let rxNostr: RxNostr;
+let relay: MockRelay;
+
+beforeEach(async () => {
+  relay = createMockRelay(RELAY_URL);
+  rxNostr = createRxNostr({
+    verifier: noopVerifier,
+    skipFetchNip11: true,
+    connectionStrategy: "lazy",
+    disconnectTimeout: 0,
+  });
+  await rxNostr.setDefaultRelays([RELAY_URL]);
+});
+
+afterEach(() => {
+  rxNostr.dispose();
+  disposeMockRelay(relay);
+});
+
+test("publish OK releases the lazy connection", async () => {
+  const event = faker.event();
+  const spy = spySubscription();
+
+  rxNostr.send(event).pipe(spy.tap()).subscribe();
+
+  await relay.connected;
+  await expect(relay).toReceiveEVENT(event);
+
+  relay.emitOK(event.id, true);
+
+  await expect(spy.willComplete()).resolves.toBe(true);
+  await expect(stateWillBe(rxNostr, RELAY_URL, "dormant")).resolves.toBe(true);
+});

--- a/packages/rx-nostr/src/connection/publish.ts
+++ b/packages/rx-nostr/src/connection/publish.ts
@@ -90,7 +90,7 @@ export class PublishProxy {
       return;
     }
 
-    if (!this.pubs.has(eventId)) {
+    if (this.pubs.has(eventId)) {
       this.pubs.delete(eventId);
       this.count$.decrement();
     }


### PR DESCRIPTION
## Summary

Fix the publish logical connection cleanup that runs after a relay returns a terminal `OK` response.

## Root cause

`PublishProxy.publish()` registers each event in `pubs` and increments the logical connection count. `confirmOK()` had the membership condition reversed, so registered events were never deleted and the count was never decremented. As a result, an otherwise idle lazy relay stayed `connected` after a successful publish.

## Changes

- Correct the `confirmOK()` membership check so registered publish state is deleted and decremented.
- Add a public-behavior regression test using a mock relay: after `EVENT` and matching `OK true`, `send()` completes and the lazy connection returns to `dormant`.

## Verification

- Targeted publish/connection tests: 12 passed.
- `npm test`: 52 passed (5 crypto, 47 rx-nostr).
- `npm run build`: passed (the existing `relay.ts:239` TypeScript diagnostic is emitted during declaration generation but does not fail the build).
- Changed-file ESLint and Prettier checks: passed.
- `npm run lint`: fails on the upstream baseline because Prettier reports existing formatting differences across 51 rx-nostr files and 9 crypto files; no unrelated formatting was changed.

Related issue: #197